### PR TITLE
807. Max Increase to Keep City Skyline

### DIFF
--- a/src/main/java/dev/hello/leetcode/max_increase_to_keep_city_skyline/Solution.java
+++ b/src/main/java/dev/hello/leetcode/max_increase_to_keep_city_skyline/Solution.java
@@ -1,0 +1,31 @@
+package dev.hello.leetcode.max_increase_to_keep_city_skyline;
+
+class Solution {
+    public int maxIncreaseKeepingSkyline(int[][] grid) {
+        if (grid.length == 0) return 0;
+
+        int[] rowSkyline = new int[grid.length];
+        int[] columnSkyline = new int[grid[0].length];
+
+        int maxIncrease = 0;
+
+        for (int i = 0; i < rowSkyline.length; i++) {
+            for (int j = 0; j < columnSkyline.length; j++) {
+                if (grid[i][j] > rowSkyline[i]) rowSkyline[i] = grid[i][j];
+                if (grid[i][j] > columnSkyline[j]) columnSkyline[j] = grid[i][j];
+            }
+        }
+
+        for (int i = 0; i < rowSkyline.length; i++) {
+            for (int j = 0; j < columnSkyline.length; j++) {
+                if (rowSkyline[i] <= columnSkyline[j]) {
+                    maxIncrease += (rowSkyline[i] - grid[i][j]);
+                } else {
+                    maxIncrease += (columnSkyline[j] - grid[i][j]);
+                }
+            }
+        }
+
+        return maxIncrease;
+    }
+}

--- a/src/main/java/dev/hello/leetcode/max_increase_to_keep_city_skyline/Solution.java
+++ b/src/main/java/dev/hello/leetcode/max_increase_to_keep_city_skyline/Solution.java
@@ -2,8 +2,6 @@ package dev.hello.leetcode.max_increase_to_keep_city_skyline;
 
 class Solution {
     public int maxIncreaseKeepingSkyline(int[][] grid) {
-        if (grid.length == 0) return 0;
-
         int[] rowSkyline = new int[grid.length];
         int[] columnSkyline = new int[grid[0].length];
 
@@ -11,18 +9,14 @@ class Solution {
 
         for (int i = 0; i < rowSkyline.length; i++) {
             for (int j = 0; j < columnSkyline.length; j++) {
-                if (grid[i][j] > rowSkyline[i]) rowSkyline[i] = grid[i][j];
-                if (grid[i][j] > columnSkyline[j]) columnSkyline[j] = grid[i][j];
+                rowSkyline[i] = Math.max(rowSkyline[i], grid[i][j]);
+                columnSkyline[j] = Math.max(columnSkyline[j], grid[i][j]);
             }
         }
 
         for (int i = 0; i < rowSkyline.length; i++) {
             for (int j = 0; j < columnSkyline.length; j++) {
-                if (rowSkyline[i] <= columnSkyline[j]) {
-                    maxIncrease += (rowSkyline[i] - grid[i][j]);
-                } else {
-                    maxIncrease += (columnSkyline[j] - grid[i][j]);
-                }
+                maxIncrease += Math.min(rowSkyline[i], columnSkyline[j]) - grid[i][j];
             }
         }
 

--- a/src/test/java/dev/hello/leetcode/max_increase_to_keep_city_skyline/SolutionTest.java
+++ b/src/test/java/dev/hello/leetcode/max_increase_to_keep_city_skyline/SolutionTest.java
@@ -1,0 +1,19 @@
+package dev.hello.leetcode.max_increase_to_keep_city_skyline;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SolutionTest {
+
+    @Test
+    void maxIncreaseKeepingSkyline() {
+        Solution solution = new Solution();
+        assertEquals(0, solution.maxIncreaseKeepingSkyline(new int[][] {}));
+        assertEquals(35, solution.maxIncreaseKeepingSkyline(new int[][] {
+                {3, 0, 8, 4},
+                {2, 4, 5, 7},
+                {9, 2, 6, 3},
+                {0, 3, 1, 0} }));
+    }
+}

--- a/src/test/java/dev/hello/leetcode/max_increase_to_keep_city_skyline/SolutionTest.java
+++ b/src/test/java/dev/hello/leetcode/max_increase_to_keep_city_skyline/SolutionTest.java
@@ -9,7 +9,6 @@ class SolutionTest {
     @Test
     void maxIncreaseKeepingSkyline() {
         Solution solution = new Solution();
-        assertEquals(0, solution.maxIncreaseKeepingSkyline(new int[][] {}));
         assertEquals(35, solution.maxIncreaseKeepingSkyline(new int[][] {
                 {3, 0, 8, 4},
                 {2, 4, 5, 7},


### PR DESCRIPTION
#### [807. Max Increase to Keep City Skyline](https://leetcode.com/problems/max-increase-to-keep-city-skyline/)
In a 2 dimensional array `grid`, each value `grid[i][j]` represents the height of a building located there. We are allowed to increase the height of any number of buildings, by any amount (the amounts can be different for different buildings). Height 0 is considered to be a building as well. 

At the end, the "skyline" when viewed from all four directions of the grid, i.e. top, bottom, left, and right, must be the same as the skyline of the original grid. A city's skyline is the outer contour of the rectangles formed by all the buildings when viewed from a distance. See the following example.

What is the maximum total sum that the height of the buildings can be increased?
```
Example:
Input: grid = [[3,0,8,4],[2,4,5,7],[9,2,6,3],[0,3,1,0]]
Output: 35
Explanation: 
The grid is:
[ [3, 0, 8, 4], 
  [2, 4, 5, 7],
  [9, 2, 6, 3],
  [0, 3, 1, 0] ]

The skyline viewed from top or bottom is: [9, 4, 8, 7]
The skyline viewed from left or right is: [8, 7, 9, 3]

The grid after increasing the height of buildings without affecting skylines is:

gridNew = [ [8, 4, 8, 7],
            [7, 4, 7, 7],
            [9, 4, 8, 7],
            [3, 3, 3, 3] ]
```
**Notes:**
- `1 < grid.length = grid[0].length <= 50`.
- All heights `grid[i][j]` are in the range `[0, 100]`.
- All buildings in `grid[i][j]` occupy the entire grid cell: that is, they are a `1 x 1 x grid[i][j]` rectangular prism.