### PR TITLE
938. Range Sum of BST

### DIFF
--- a/src/main/java/dev/hello/leetcode/range_sum_of_bst/Solution.java
+++ b/src/main/java/dev/hello/leetcode/range_sum_of_bst/Solution.java
@@ -4,12 +4,10 @@ import dev.hello.structures.TreeNode;
 
 class Solution {
 
-    private int rangeSum = 0;
-
     public int rangeSumBST(TreeNode root, int L, int R) {
-        if (root.val >= L && root.val <= R) rangeSum += root.val;
-        if (root.left != null ) rangeSumBST(root.left, L, R);
-        if (root.right != null ) rangeSumBST(root.right, L, R);
-        return rangeSum;
+        if (root == null) return 0;
+        if (root.val < L) return rangeSumBST(root.right, L , R);
+        if (root.val > R) return rangeSumBST(root.left, L, R);
+        return  root.val + rangeSumBST(root.right, L , R) + rangeSumBST(root.left, L, R);
     }
 }

--- a/src/main/java/dev/hello/leetcode/range_sum_of_bst/Solution.java
+++ b/src/main/java/dev/hello/leetcode/range_sum_of_bst/Solution.java
@@ -1,0 +1,15 @@
+package dev.hello.leetcode.range_sum_of_bst;
+
+import dev.hello.structures.TreeNode;
+
+class Solution {
+
+    private int rangeSum = 0;
+
+    public int rangeSumBST(TreeNode root, int L, int R) {
+        if (root.val >= L && root.val <= R) rangeSum += root.val;
+        if (root.left != null ) rangeSumBST(root.left, L, R);
+        if (root.right != null ) rangeSumBST(root.right, L, R);
+        return rangeSum;
+    }
+}

--- a/src/test/java/dev/hello/leetcode/range_sum_of_bst/SolutionTest.java
+++ b/src/test/java/dev/hello/leetcode/range_sum_of_bst/SolutionTest.java
@@ -1,0 +1,30 @@
+package dev.hello.leetcode.range_sum_of_bst;
+
+import dev.hello.structures.TreeNode;
+import dev.hello.utils.TreeUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SolutionTest {
+
+    @Test
+    void rangeSumBST1() {
+        Integer[] source = new Integer[] { 10, 5, 15, 3, 7, null, 18 };
+        TreeNode root = TreeUtil.loadNodeBfs(source);
+        assertNotNull(root);
+
+        Solution solution = new Solution();
+        assertEquals(32, solution.rangeSumBST(root, 7, 15));
+    }
+
+    @Test
+    void rangeSumBST2() {
+        Integer[] source = new Integer[] { 10, 5, 15, 3, 7, 13, 18, 1, null, 6 };
+        TreeNode root = TreeUtil.loadNodeBfs(source);
+        assertNotNull(root);
+
+        Solution solution = new Solution();
+        assertEquals(23, solution.rangeSumBST(root, 6, 10));
+    }
+}


### PR DESCRIPTION
#### [938. Range Sum of BST](https://leetcode.com/problems/range-sum-of-bst/)
Given the `root` node of a binary search tree, return the sum of values of all nodes with value between `L` and `R` (inclusive).

The binary search tree is guaranteed to have unique values.

**Example 1**:
```
Input: root = [10,5,15,3,7,null,18], L = 7, R = 15
Output: 32
```
**Example 2**:
```
Input: root = [10,5,15,3,7,13,18,1,null,6], L = 6, R = 10
Output: 23
```

**Note**:
1. The number of nodes in the tree is at most `10000`.
2. The final answer is guaranteed to be less than `2^31`.