### PR TITLE
1111. Maximum Nesting Depth of Two Valid Parentheses Strings

### DIFF
--- a/src/main/java/dev/hello/leetcode/maximum_nesting_depth_of_two_valid_parentheses_strings/Solution.java
+++ b/src/main/java/dev/hello/leetcode/maximum_nesting_depth_of_two_valid_parentheses_strings/Solution.java
@@ -1,0 +1,22 @@
+package dev.hello.leetcode.maximum_nesting_depth_of_two_valid_parentheses_strings;
+
+import java.util.Stack;
+
+class Solution {
+    public int[] maxDepthAfterSplit(String seq) {
+        Stack<Character> stack = new Stack<>();
+        int[] depth = new int[seq.length()];
+
+        for (int i = 0; i < seq.length(); i++) {
+            if (seq.charAt(i) == '(') {
+                stack.push(seq.charAt(i));
+                depth[i] = stack.size() % 2;
+            } else {
+                depth[i] = stack.size() % 2;
+                stack.pop();
+            }
+        }
+
+        return depth;
+    }
+}

--- a/src/main/java/dev/hello/leetcode/maximum_nesting_depth_of_two_valid_parentheses_strings/Solution.java
+++ b/src/main/java/dev/hello/leetcode/maximum_nesting_depth_of_two_valid_parentheses_strings/Solution.java
@@ -3,16 +3,9 @@ package dev.hello.leetcode.maximum_nesting_depth_of_two_valid_parentheses_string
 class Solution {
     public int[] maxDepthAfterSplit(String seq) {
         int[] depth = new int[seq.length()];
-        int group = -1;
 
         for (int i = 0; i < seq.length(); i++) {
-            if (seq.charAt(i) == '(') {
-                group++;
-                depth[i] = group % 2;
-            } else {
-                depth[i] = group % 2;
-                group--;
-            }
+            depth[i] = (seq.charAt(i) == '(') ? i & 1 : (1 - i & 1);
         }
 
         return depth;

--- a/src/main/java/dev/hello/leetcode/maximum_nesting_depth_of_two_valid_parentheses_strings/Solution.java
+++ b/src/main/java/dev/hello/leetcode/maximum_nesting_depth_of_two_valid_parentheses_strings/Solution.java
@@ -1,19 +1,17 @@
 package dev.hello.leetcode.maximum_nesting_depth_of_two_valid_parentheses_strings;
 
-import java.util.Stack;
-
 class Solution {
     public int[] maxDepthAfterSplit(String seq) {
-        Stack<Character> stack = new Stack<>();
         int[] depth = new int[seq.length()];
+        int group = -1;
 
         for (int i = 0; i < seq.length(); i++) {
             if (seq.charAt(i) == '(') {
-                stack.push(seq.charAt(i));
-                depth[i] = stack.size() % 2;
+                group++;
+                depth[i] = group % 2;
             } else {
-                depth[i] = stack.size() % 2;
-                stack.pop();
+                depth[i] = group % 2;
+                group--;
             }
         }
 

--- a/src/test/java/dev/hello/leetcode/maximum_nesting_depth_of_two_valid_parentheses_strings/SolutionTest.java
+++ b/src/test/java/dev/hello/leetcode/maximum_nesting_depth_of_two_valid_parentheses_strings/SolutionTest.java
@@ -11,7 +11,7 @@ class SolutionTest {
     @Test
     void maxDepthAfterSplit() {
         Solution solution = new Solution();
-        assertEquals("[1, 0, 0, 0, 0, 1]", Arrays.toString(solution.maxDepthAfterSplit("(()())")));
-        assertEquals("[1, 1, 1, 0, 0, 1, 1, 1]", Arrays.toString(solution.maxDepthAfterSplit("()(())()")));
+        assertEquals("[0, 1, 1, 1, 1, 0]", Arrays.toString(solution.maxDepthAfterSplit("(()())")));
+        assertEquals("[0, 0, 0, 1, 1, 0, 0, 0]", Arrays.toString(solution.maxDepthAfterSplit("()(())()")));
     }
 }

--- a/src/test/java/dev/hello/leetcode/maximum_nesting_depth_of_two_valid_parentheses_strings/SolutionTest.java
+++ b/src/test/java/dev/hello/leetcode/maximum_nesting_depth_of_two_valid_parentheses_strings/SolutionTest.java
@@ -1,0 +1,17 @@
+package dev.hello.leetcode.maximum_nesting_depth_of_two_valid_parentheses_strings;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SolutionTest {
+
+    @Test
+    void maxDepthAfterSplit() {
+        Solution solution = new Solution();
+        assertEquals("[1, 0, 0, 0, 0, 1]", Arrays.toString(solution.maxDepthAfterSplit("(()())")));
+        assertEquals("[1, 1, 1, 0, 0, 1, 1, 1]", Arrays.toString(solution.maxDepthAfterSplit("()(())()")));
+    }
+}


### PR DESCRIPTION
### Description
A string is a _valid parentheses string_ (denoted VPS) if and only if it consists of `"("` and `")"` characters only, and:

It is the empty string, or
It can be written as `AB` (`A` concatenated with `B`), where `A` and `B` are VPS's, or
It can be written as `(A)`, where `A` is a VPS.
We can similarly define the nesting depth `depth(S)` of any VPS `S` as follows:

- `depth("") = 0`
- `depth(A + B) = max(depth(A), depth(B))`, where `A` and `B` are VPS's
- `depth("(" + A + ")") = 1 + depth(A)`, where `A` is a VPS.

For example,  `""`, `"()()"`, and `"()(()())"` are VPS's (with nesting depths 0, 1, and 2), and `")("` and `"(()"` are not VPS's.

 

Given a VPS seq, split it into two disjoint subsequences `A` and `B`, such that `A` and `B` are VPS's (and `A.length + B.length = seq.length`).

Now choose **any** such `A` and `B` such that `max(depth(A), depth(B))` is the minimum possible value.

Return an `answer` array (of length `seq.length`) that encodes such a choice of `A` and `B`:  `answer[i] = 0` if `seq[i]` is part of `A`, else `answer[i] = 1`.  Note that even though multiple answers may exist, you may return any of them.

 

**Example 1**:
```
Input: seq = "(()())"
Output: [0,1,1,1,1,0]
```
**Example 2**:
```
Input: seq = "()(())()"
Output: [0,0,0,1,1,0,1,1]
```

**Constraints**:

- `1 <= seq.size <= 10000`

### Note
Actually even you don't have the same result as examples, you could still AC the problem.